### PR TITLE
Change LaunchPath and CurrentDirectoryPath to support Arduino IDE 1.6.x

### DIFF
--- a/Sources/HexLoaderController.m
+++ b/Sources/HexLoaderController.m
@@ -213,8 +213,8 @@
          
          NSLog(@"");
          
-         [task setLaunchPath:@"/Applications/Arduino.app/Contents/Resources/Java/hardware/tools/avr/bin/avrdude"];
-         [task setCurrentDirectoryPath:@"/Applications/Arduino.app/Contents/Resources/Java/hardware/tools/avr/etc"];
+         [task setLaunchPath:@"/Applications/Arduino.app/Contents/Java/hardware/tools/avr/bin/avrdude"];
+         [task setCurrentDirectoryPath:@"/Applications/Arduino.app/Contents/Java/hardware/tools/avr/etc"];
         
          NSArray *args = [NSArray arrayWithObjects:
                             @"-F",


### PR DESCRIPTION
This will fix #2 

Not sure if we should still support the older Arduino IDEs. Maybe we can allow people to choose from a list which version they are using and set the paths this way.